### PR TITLE
Automatically download and update the language server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,91 @@
+use std::fs;
+
 use zed_extension_api::{self as zed, serde_json, settings::LspSettings};
 
-struct CurryExtension;
+struct CurryExtension {
+    cached_binary_path: Option<String>,
+}
+
+impl CurryExtension {
+    fn language_server_binary_path(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+    ) -> zed::Result<String> {
+        if let Some(path) = &self.cached_binary_path {
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+                return Ok(path.clone());
+            }
+        }
+
+        zed::set_language_server_installation_status(
+            &language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let release = zed::latest_github_release(
+            "fwcd/curry-language-server",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false
+            },
+        )?;
+
+        let (os, arch) = zed::current_platform();
+        let suffix = match (os, arch) {
+            (zed::Os::Windows, zed::Architecture::X8664) => "amd64-windows",
+            (zed::Os::Mac, zed::Architecture::Aarch64) => "arm64-darwin",
+            (zed::Os::Mac, zed::Architecture::X8664) => "x86_64-darwin",
+            (zed::Os::Linux, zed::Architecture::X8664) => "x86_64-linux",
+            _ => return Err(format!("The platform {os:?}/{arch:?} is not supported by curry-language-server")),
+        };
+
+        let asset_name = format!("curry-language-server-{suffix}.zip");
+        let asset = release.assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("Could not find asset {asset_name} in curry-language-server release"))?;
+
+        let version_dir = format!("curry-language-server-{}", release.version);
+        let binary_path = format!(
+            "{version_dir}/bin/curry-language-server{extension}",
+            extension = match os {
+                zed::Os::Windows => ".exe",
+                _ => "",
+            }
+        );
+
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                &language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(
+                &asset.download_url,
+                &version_dir,
+                zed::DownloadedFileType::Zip
+            )
+            .map_err(|e| format!("Failed to download curry-language-server artifact: {e}"))?;
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
+    }
+}
 
 impl zed::Extension for CurryExtension {
     fn new() -> Self {
-        Self
+        Self {
+            cached_binary_path: None,
+        }
     }
 
     fn language_server_command(
         &mut self,
-        _language_server_id: &zed::LanguageServerId,
-        worktree: &zed::Worktree,
+        language_server_id: &zed::LanguageServerId,
+        _worktree: &zed::Worktree,
     ) -> zed::Result<zed::Command> {
-        let Some(path) = worktree.which("curry-language-server") else {
-            return Err("Could not find curry-language-server on PATH".into());
-        };
-
         Ok(zed::Command {
-            command: path,
+            command: self.language_server_binary_path(language_server_id)?,
             args: vec![],
             env: Default::default(),
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fs::{self, Permissions}, os::unix::fs::PermissionsExt};
+use std::{fs, process::Command};
 
 use zed_extension_api::{self as zed, serde_json, settings::LspSettings};
 
@@ -68,7 +68,10 @@ impl CurryExtension {
 
             // Mark the binary as executable since this mode seems to be gone after unzipping
             if matches!(os, zed::Os::Mac | zed::Os::Linux) {
-                fs::set_permissions(&binary_path, Permissions::from_mode(0o755))
+                Command::new("chmod")
+                    .arg("+x")
+                    .arg(&binary_path)
+                    .output()
                     .map_err(|e| format!("Could not mark curry-language-server binary as executable: {e}"))?;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs::{self, Permissions}, os::unix::fs::PermissionsExt};
 
 use zed_extension_api::{self as zed, serde_json, settings::LspSettings};
 
@@ -65,6 +65,12 @@ impl CurryExtension {
                 zed::DownloadedFileType::Zip
             )
             .map_err(|e| format!("Failed to download curry-language-server artifact: {e}"))?;
+
+            // Mark the binary as executable since this mode seems to be gone after unzipping
+            if matches!(os, zed::Os::Mac | zed::Os::Linux) {
+                fs::set_permissions(&binary_path, Permissions::from_mode(0o755))
+                    .map_err(|e| format!("Could not mark curry-language-server binary as executable: {e}"))?;
+            }
         }
 
         self.cached_binary_path = Some(binary_path.clone());


### PR DESCRIPTION
This implements a similar logic as https://github.com/zed-extensions/kotlin, fetching binary releases from GitHub and managing a language server installation in a Zed-provided application support directory.

Marked as a draft for now, since unfortunately it does not really seem to work yet. Even with tarballs instead of zips, the binary doesn't seem to be executable after unarchiving (at least not immediately, maybe there is a race condition with some kind of quarantining mechanism by macOS that delays marking the file executable?).